### PR TITLE
Removed Slur from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ A Lambdascript program is logically split into blocks of code in the whole Markd
 A Lambdascript block of code is a comma-separated collection of declarations. Unlike Python, Lambdascript does not care at all about indentations; furthermore, it does not care either about order of declarations inside a given code block. An example of a simple block of code is:
 
     f: lambda n: 2*n,
-    a: 42,
-    g: lambda n: f(n)+a
+    x: 42,
+    g: lambda n: f(n)+x
 
 Since order does not matter, the very same block could be written:
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ A Lambdascript block of code is a comma-separated collection of declarations. Un
 
 Since order does not matter, the very same block could be written:
 
-    g: lambda n: f(n)+a
+    g: lambda n: f(n)+x
         # where
         ,    f: lambda n: 2*n
-        ,    a: 42
+        ,    x: 42
 
 Each declaration being made of a label and any Python expression (generally a lambda function).
 


### PR DESCRIPTION
I'm sure this was accidental, but in one of the Readme examples, the variable names chosen formed an unfortunate [acrostic](https://en.wikipedia.org/wiki/Acrostic).